### PR TITLE
feat(idleTimeout): Timeout option configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Configuration is done through specification of environment variables.
 | `WEBSOCKET_SERVER_HOST` | `0.0.0.0` | Specifies the host interface to listen on for WebSocket requests. |
 | `WEBSOCKET_SERVER_CERT_FILE_NAME` | `N/A` | Path to certificate file that will be used for secure websocket requests. |
 | `WEBSOCKET_SERVER_KEY_FILE_NAME` | `N/A` | Path to key that will be used for secure websoket server requests. |
+| `WEBSOCKET_SERVER_IDLE_TIMEOUT` | `600` | Specifies the amount of time in seconds to wait between WebSocket connection messages before closing down the connection.|
 | `LOG_LEVEL` | `INFO` | Specifies the log level. Valid values are `TRACE`, `DEBUG`, `INFO`, `WARN` and `OFF`. |
 | `ANNEXB_ENABLED` | `YES` | Specifies if annexb should be used for the codec. |
 

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('g729-codec-service','c', 'cpp', version: '0.0.1', default_options : ['c_std=c17', 'cpp_std=c++17'])
+project('g729-codec-service','c', 'cpp', version: '0.0.2', default_options : ['c_std=c17', 'cpp_std=c++17'])
 usockets = subproject('usockets')
 rapidjson = subproject('rapidjson')
 uwebsockets = subproject('uwebsockets')

--- a/src/NetworkOptions.hpp
+++ b/src/NetworkOptions.hpp
@@ -22,14 +22,16 @@
 
 const std::string defaultAddress = "0.0.0.0";
 const int defaultPort = 9001;
+const int defaultIdleTimeout = 600; // Seconds
 
 struct NetworkOptions {
   std::string addr;
   int port;
+  int idleTimeout;
 };
 
 NetworkOptions generateNetworkOptions() {
-  NetworkOptions networkOptions = {defaultAddress, defaultPort};
+  NetworkOptions networkOptions = {defaultAddress, defaultPort, defaultIdleTimeout};
 
   if (const char *websocketServerHost = std::getenv("WEBSOCKET_SERVER_HOST")) {
     networkOptions.addr = websocketServerHost;
@@ -41,6 +43,10 @@ NetworkOptions generateNetworkOptions() {
 
   if (const char *port = std::getenv("WEBSOCKET_SERVER_PORT")) {
     networkOptions.port = (int)std::strtol(port, NULL, 10);
+  }
+
+  if (const char *idleTimeout = std::getenv("WEBSOCKET_SERVER_IDLE_TIMEOUT")) {
+    networkOptions.idleTimeout = (int) std::strtol(idleTimeout, NULL, 10);
   }
 
   return networkOptions;


### PR DESCRIPTION
Changes default timeout to 60 seconds, and makes it configurable through
the "WEBSOCKET_SERVER_IDLE_TIMEOUT" env variable configuration.